### PR TITLE
[BUGFIX] Default to 'text' for fenced code blocks with no language identifier

### DIFF
--- a/template/filter.lua
+++ b/template/filter.lua
@@ -401,7 +401,7 @@ if FORMAT:match 'html' then
   end
 
   function CodeBlock(block)
-    lang = block.classes[1]
+    lang = block.classes[1] or 'text'
     code = block.text
     filename = "pygmentize.txt"
 


### PR DESCRIPTION
Plain Markdown fenced code blocks like this:
```
some code
```
error out with: **Error: no lexer for alias 'nil' found.**

I added 'text' as a default value for the lexer so that unidentified fenced code is parsed correctly.